### PR TITLE
Adding an optional playbutton param, to show a play button

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,8 @@ app.get('/', function(req, res) {
         names: validNames,
         anyValidNames: validNames.length > 0,
         namesString: validNames.join(','),
-        embeddable: req.query.embeddable
+        embeddable: req.query.embeddable,
+        playbutton: req.query.playbutton
       });
     });
   } else {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,7 +1,8 @@
 // weird thing with MIDI lib. vOv
-!function(global, $, MIDI){
+var songOfGitHub = function(global, $, MIDI){
   'use strict';
 
+  var allWeeks = [];
   var mapping = {
         'fill: #eeeeee;': 0,
         'fill: #d6e685;': 1,
@@ -155,20 +156,48 @@
       }
       return noteDelay;
     }
-  }
+  };
 
-  $(function(){
-    var weeks, i;
-    var allWeeks = [];
-
-    for (i = 0; i < names.length; i++) {
-      weeks = organizeData(global.data[names[i]]);
-      loadVisualization(weeks, names[i]);
-      allWeeks.push(weeks)
-    }
-
+  function playSong() {
     if (allWeeks.length > 0) {
       loadSong(allWeeks);
     }
-  });
+    return false;
+  };
+
+  function showVisualization() {
+    if (allWeeks.length == 0) {
+      var weeks, i;
+      for (i = 0; i < names.length; i++) {
+        weeks = organizeData(global.data[names[i]]);
+        loadVisualization(weeks, names[i]);
+        allWeeks.push(weeks)
+      }
+    }
+  };
+
+  function buildPlayButton() {
+   var playButton = jQuery('<a/>', {
+      href: '#',
+      html: '&rtrif; Click to play'
+    })
+    playButton.click(function(e){
+      songOfGitHub.playSong();
+    });
+    playButton.insertAfter('#visualize');
+  }
+
+  function init(autoPlay) {
+    showVisualization();
+    if(autoPlay) {
+      playSong();
+    } else {
+      buildPlayButton();
+    }
+  };
+
+  return {
+    init: init,
+    playSong: playSong
+  }
 }(this, jQuery, MIDI);

--- a/views/index.hjs
+++ b/views/index.hjs
@@ -79,6 +79,13 @@
     <script src='/js/index.js' type='text/javascript'></script>
 
     <script type='text/javascript'>
+      {{^playbutton}}
+      songOfGitHub.init(true);
+      {{/playbutton}}
+      {{#playbutton}}
+      songOfGitHub.init();
+      {{/playbutton}}
+
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-37501388-1']);
       _gaq.push(['_trackPageview']);


### PR DESCRIPTION
Having the song play after page load was a little annoying for me when I used the embeddable option.  This commit introduces a new `&playbutton` param.  

If present a link labelled **▸ Click to play** is appended and the tune will not start until you click it.

A new global object `songOfGitHub` was introduced to deal with this, and `allWeeks` array was pulled up.
