### PR TITLE
fix: github changed endpoint for contributions calendar

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.configure('development', function() {
 
 getGitHubData = function(name) {
   var deferred = Q.defer(),
-      url = 'https://github.com/users/' + name + '/contributions_calendar_data';
+      url = 'https://github.com/users/' + name + '/contributions';
 
   https.get(url, function(res) {
     var body = '';


### PR DESCRIPTION
GitHub changed the endpoint for the contributions calendar,
now is  [https://github.com/users/[USER]/contributions](https://github.com/users/mudler/contributions)
