### PR TITLE
FOO the denominator to prevent negative delays

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -169,10 +169,11 @@ function playWeek(week, n, name) {
 
   function getDelay() {
     if (arpeggio) {
-      noteDelay = delay + (m / chordMap.length - 1);
+      noteDelay = delay + (m / (chordMap.length - 1));
     } else {
      noteDelay = delay;
     }
+
     return noteDelay;
   }
 };


### PR DESCRIPTION
For the first chord it is possible for noteDelay to equal -1 because the
“- 1” is not wrapped in the denominator:

```
0 + (0 / 6 - 1) = -1
```

But the intended order is:

```
0 + (0 / (6 - 1)) = 0
```

If the AudioContext is created quickly enough its `currentTime` is 0
during the first calculation, which results in a negative start time and
throws an exception in MIDI.js.

Fixes #31.
